### PR TITLE
Use ffmpeg amix instead of amerge

### DIFF
--- a/fauxstream
+++ b/fauxstream
@@ -199,7 +199,7 @@ VIDEO="-video_size $resolution \
 -g $gop \
 -keyint_min $framerate"
 
-AUDIOMERGE="volume=$volume_mic,aformat=channel_layouts=stereo$hilopass[l];[1]volume=$volume_mon,aformat=channel_layouts=stereo[m];[l][m]amerge=inputs=2[a]"
+AUDIOMERGE="volume=$volume_mic,aformat=channel_layouts=stereo$hilopass[l];[1]volume=$volume_mon,aformat=channel_layouts=stereo[m];[l][m]amix=inputs=2[a]"
 
 # if no mic (= no -m), only record from snd/0.mon
 #	and the only filter is aresample=async=1


### PR DESCRIPTION
I was running into an issue under OpenBSD 6.9-stable where my snd/0.mon audio wasn't coming through when streaming or when recording to file, only my mic was. It turns out `ffmpeg`'s `amerge` with stereo inputs will give quad output, so it was suggested to me to use `amix` instead. That resolved the issue.

This also fixes Twitch streams from `fauxstream` not working in the mobile app. Bonus!