### PR TITLE
Add fullscreen support

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,14 +61,18 @@ Usage
 -----
 
 ```
-fauxstream [-vmon <factor>] [-m [-vmic <factor>]] [-r <size>]
+fauxstream [-vmon <factor>] [-m [-vmic <factor>]]
+    [-r <size> [-o <offset>] | -fullscreen | -n <name>]
 	[-f <framerate>] [-a <seconds>] <target>
 
 -m:	enable microphone stream (in addition to monitoring stream)
 -vmon:	factor to adjust volume of the monitoring stream
 -vmic:	factor to adjust volume of the microphone stream
--r:	set video size (resolution)
--f:	set video framerate
+-r:	set video size (resolution; default: 1280x720)
+-o: set video offset (from top left; default: +0,0)
+-fullscreen: set video size & offset to root window geometry (supersedes -r and -o)
+-n: set video size to geometry of named window (supersedess -r, -o, and -fullscreen)
+-f:	set video framerate (default: 30)
 -a:	set audio offset (in seconds; can be negative)
 
 The target can be a file or a remote streaming address (`rtmp://`).
@@ -102,6 +106,14 @@ particular anymore.
 **Q: How do I stop the recording??**
 
 A: Press Ctrl-C to stop the recording.
+
+**Q: I'm trying to record a specific window, but why does moving it
+or covering it not keep recording it?**
+
+A: Unfortunately, it's just recording the screen geometry of where
+the window was when you started recording. Any overlapping windows
+will be included in the recorded area and moving the window will
+result in it moving outside of the recorded area.
 
 Related Links:
 --------------

--- a/fauxstream
+++ b/fauxstream
@@ -27,8 +27,6 @@
 #   resolution?
 # - mention need to stop recording with Ctrl-C??
 # - add highpass=f=200,lowpass=f=3000
-# - document default resolution (if no window name provided) of 1920x1080
-# - document that if -n is not given, will default to root window
 # - document windowname (-n) needs to be in "" if multiple words
 # - document that window needs to be visible/on top
 # - link for finding twitch servers:
@@ -36,8 +34,6 @@
 # - does -s option need to be in "" ? -> should not be needed
 # - document that compositor has negative effect on smoothness
 # - framerate 29 seems to be better than 30 in regads to Twitch stream health
-# - should be either resolution (-r) (+ offset (-o)), window name (-n), or fullscreen (-fullscreen)
-#   -> should ideally default to geometry with default of 1280x720+0+0
 # - document '-m' turns on recording from mic
 # - '-m' currently uses hardcoded snd/0
 # - may not need as many 'thread_queue_size options, but definitely for the -f sndio inputs

--- a/fauxstream
+++ b/fauxstream
@@ -40,7 +40,6 @@
 #   -> should ideally default to geometry with default of 1280x720+0+0
 # - document '-m' turns on recording from mic
 # - '-m' currently uses hardcoded snd/0
-# - fix '-fullscreen' parameter (not working correctly)
 # - may not need as many 'thread_queue_size options, but definitely for the -f sndio inputs
 # - Cryptark crashes/hangs on this Ryzen 7 2700
 # - add '-s $OUTRES' ??
@@ -158,8 +157,34 @@ fi
 
 sndio_device="$(sndioctl server.device | cut -f2 -d=)"
 
-# if -n was used, overwrite resolution with window parameters
-if [[ -n "$windowname" ]];then
+echo -n "Recording geometry ("
+# if -r was used
+if [ $resolution != "1280x720" -a -z "$windowname" ];then
+  echo -n "custom"
+  # if -fullscreen was used, overwrite resolution with root window parameters (overrides -r and -o)
+elif [ $fullscreen -eq 1 ]; then
+  xline=`xwininfo -name "$windowname" | grep "Absolute upper-left X"`
+	yline=`xwininfo -name "$windowname" | grep "Absolute upper-left Y"`
+	widthline=`xwininfo -root | grep "Width:"`
+	heightline=`xwininfo -root | grep "Height:"`
+	xval=`echo "$xline" | cut -f 7 -d " "`
+	yval=`echo "$yline" | cut -f 7 -d " "`
+  # width and height need to be multiples of 2
+  # in the case of fullscreen, contract by 1px (if necessary; seems unlikely to happen)
+	widthval=`echo "$widthline" | cut -f 4 -d " "`
+	if [[ `expr $widthval % 2` -eq 1 ]]; then
+		widthval=`expr $widthval - 1`
+	fi
+	heightval=`echo "$heightline" | cut -f 4 -d " "`
+	if [[ `expr $heightval % 2` -eq 1 ]]; then
+		heightval=`expr $heightval - 1`
+	fi
+	resolution="${widthval}x${heightval}"
+	offset="+${xval},${yval}"
+
+  echo -n "fullscreen"
+# if -n was used, overwrite resolution with window parameters (overrides -r, -o, and -fullscreen)
+elif [[ -n "$windowname" ]];then
 	xline=`xwininfo -name "$windowname" | grep "Absolute upper-left X"`
 	yline=`xwininfo -name "$windowname" | grep "Absolute upper-left Y"`
 	widthline=`xwininfo -name "$windowname" | grep "Width:"`
@@ -167,6 +192,7 @@ if [[ -n "$windowname" ]];then
 	xval=`echo "$xline" | cut -f 7 -d " "`
 	yval=`echo "$yline" | cut -f 7 -d " "`
 	# width and height need to be multiples of 2
+  # in the case of windows, expand by 1px (if necessary)
 	widthval=`echo "$widthline" | cut -f 4 -d " "`
 	if [[ `expr $widthval % 2` -eq 1 ]]; then
 		widthval=`expr $widthval + 1`
@@ -177,7 +203,12 @@ if [[ -n "$windowname" ]];then
 	fi
 	resolution="${widthval}x${heightval}"
 	offset="+${xval},${yval}"
+
+  echo -n "$windowname"
+else
+  echo -n "default"
 fi
+echo -n "): ${resolution}${offset}\n"
 
 echo "Press Ctrl+C to stop recording\n" >& 2
 


### PR DESCRIPTION
This implements the `-fullscreen` option by using `xwininfo -root` and, in the unlikely chance that the dimensions are not multiples of 2, will decrease by 1 pixel, as appropriate. It also now outputs the recording resolution & offset (including whether it was default, custom, fullscreen, or window), and sets an order of precedence for the `-r`, `-o`, `-fullscreen`, and `-n` options. I also updated the README to document the changes.

I wasn't sure of the precedence order for the options (now `-n` > `-fullscreen` > `-r`/`-o` > defaults), but happy to adjust, if you'd like.