### PR TITLE
Fix cbr encoding

### DIFF
--- a/fauxstream
+++ b/fauxstream
@@ -228,9 +228,9 @@ VIDEO="\
 -thread_queue_size 512 \
 -f x11grab \
 -video_size $resolution \
+-framerate $framerate \
 -i $DISPLAY$offset \
 -r $framerate \
--framerate $framerate \
 -c:v $videocodec \
 -profile:v high \
 -b:v ${video_bitrate}k \

--- a/fauxstream
+++ b/fauxstream
@@ -58,12 +58,13 @@
 #   and
 #   https://blog.twitch.tv/en/2017/10/10/live-video-transmuxing-transcoding-f-fmpeg-vs-twitch-transcoder-part-i-489c1c125f28/
 
-USAGE="Usage: `basename $0` [-m] [-d mic_device] [-a audiooffset] [-n window_name] [-c codec] [-b bitrate] [-r resolution] [-o offset] [-fullscreen] [-s <scale_x>:<scale_y>] [-f framerate] [-v volume_adjustment] [-vmic mic_volume] [-vmon monitor_volume] [-t threads ] [-noaudio] [-crf crf] <rtmp url>"
+USAGE="Usage: `basename $0` [-m] [-d mic_device] [-a audiooffset] [-ab audio_bitrate] [-n window_name] [-c codec] [-vb bitrate] [-r resolution] [-o offset] [-fullscreen] [-s <scale_x>:<scale_y>] [-f framerate] [-v volume_adjustment] [-vmic mic_volume] [-vmon monitor_volume] [-t threads ] [-noaudio] [-crf crf] <rtmp url>"
 
 # Parse arguments based on http://www.shelldorado.com/goodcoding/cmdargs.html
 
 audiooffset=0.0
-bitrate=3500
+audio_bitrate=96
+video_bitrate=3500
 bufsize=
 container=flv
 filename=
@@ -121,8 +122,9 @@ fi
 while [[ $# -gt 0 ]]
 do
 	case "$1" in
-		-a) audiooffset="$2"; shift;;
-		-b) bitrate="$2"; shift;;
+		-a|-ao) audiooffset="$2"; shift;;
+		--ab) audio_bitrate="$2" ; shift;;
+		-b|-vb) video_bitrate="$2"; shift;;
 		-c) videocodec="$2"; shift;;
 		-container) container="$2"; shift;;
 		-crf) crf="$2"; shift;;
@@ -152,7 +154,7 @@ if [[ -z "$filename" ]];then
 	echo $USAGE; exit 0
 fi
 
-bufsize=`expr $bitrate \* 2`
+bufsize=`expr $video_bitrate \* 2`
 gop=`expr $framerate \* 2`
 
 if [[ -n "$scaleres" ]];then
@@ -228,16 +230,20 @@ VIDEO="-video_size $resolution \
 -i $DISPLAY$offset \
 -r $framerate \
 -c:v $videocodec \
--b:v ${bitrate}k \
--minrate ${bitrate}k \
--maxrate ${bitrate}k \
+-b:v ${video_bitrate}k \
+-minrate ${video_bitrate}k \
+-maxrate ${video_bitrate}k \
 -bufsize ${bufsize}k \
 -preset ultrafast \
--profile:v main \
+-profile:v high \
 -vf "${scaleres}format=yuv420p" \
--keyint_min $framerate \
 -g $gop \
+-keyint_min $framerate \
 -x264-params no-scenecut=1"
+
+AUDIO="-c:a aac \
+-b:a ${audio_bitrate}k \
+-aac_coder fast"
 
 AUDIOMERGE="volume=$volume_mic,aformat=channel_layouts=stereo$hilopass[l];[1]volume=$volume_mon,aformat=channel_layouts=stereo[m];[l][m]amix=inputs=2[a]"
 
@@ -246,13 +252,13 @@ AUDIOMERGE="volume=$volume_mic,aformat=channel_layouts=stereo$hilopass[l];[1]vol
 
 if [ $noaudio -lt 1 -a $mic -lt 1 ]; then
 	#only monitoring stream
-	ffmpeg $BASE -f sndio -i snd/$sndio_device.mon -c:a aac -f nut pipe:1 | \
+  ffmpeg $BASE -f sndio -i snd/$sndio_device.mon $AUDIO -f nut pipe:1 | \
 	ffmpeg $BASE -f nut -itsoffset $audiooffset -i pipe:0 $VIDEO -c:a copy -f "${container}" "$filename"
 elif [ $noaudio -lt 1 ]; then
 	#mon + mic stream
 	ffmpeg $BASE -thread_queue_size 512 -f sndio -i "$mic_device" \
 	-thread_queue_size 512 -f sndio -i snd/$sndio_device.mon \
-	-filter_complex "[0]${AUDIOMERGE}" -map '[a]' -c:a aac -f nut pipe:1 | \
+	-filter_complex "[0]${AUDIOMERGE}" -map '[a]' $AUDIO -f nut pipe:1 | \
 	ffmpeg $BASE -thread_queue_size 512 -f nut -itsoffset $audiooffset -i pipe:0 $VIDEO -c:a copy -f "${container}" "$filename"
 else
 	#no audio

--- a/fauxstream
+++ b/fauxstream
@@ -49,6 +49,14 @@
 # - audio offset needs to be applied to the audio in the second ffmpeg,
 #   right of the pipe. This clearly worked as opposed to left of the pipe
 #   with Rogue Legacy recording at 900p 60fps.
+# - it's suggested to encode at a constant bitrate (CBR) to prevent buffering,
+#   dropped frames, and "broadcast starvation" per
+#   https://help.twitch.tv/s/article/broadcasting-guidelines
+# - keyframing should be every 2s and automatic scene change detection should
+#   be disabled per
+#   https://videoblerg.wordpress.com/2016/08/16/how-to-create-abr-content-with-ffmpeg-in-one-pass/
+#   and
+#   https://blog.twitch.tv/en/2017/10/10/live-video-transmuxing-transcoding-f-fmpeg-vs-twitch-transcoder-part-i-489c1c125f28/
 
 USAGE="Usage: `basename $0` [-m] [-d mic_device] [-a audiooffset] [-n window_name] [-c codec] [-b bitrate] [-r resolution] [-o offset] [-fullscreen] [-s <scale_x>:<scale_y>] [-f framerate] [-v volume_adjustment] [-vmic mic_volume] [-vmon monitor_volume] [-t threads ] [-noaudio] [-crf crf] <rtmp url>"
 
@@ -220,14 +228,16 @@ VIDEO="-video_size $resolution \
 -i $DISPLAY$offset \
 -r $framerate \
 -c:v $videocodec \
--vb ${bitrate}k \
+-b:v ${bitrate}k \
 -minrate ${bitrate}k \
 -maxrate ${bitrate}k \
 -bufsize ${bufsize}k \
 -preset ultrafast \
+-profile:v main \
 -vf "${scaleres}format=yuv420p" \
+-keyint_min $framerate \
 -g $gop \
--keyint_min $framerate"
+-x264-params no-scenecut=1"
 
 AUDIOMERGE="volume=$volume_mic,aformat=channel_layouts=stereo$hilopass[l];[1]volume=$volume_mon,aformat=channel_layouts=stereo[m];[l][m]amix=inputs=2[a]"
 

--- a/fauxstream
+++ b/fauxstream
@@ -123,7 +123,7 @@ while [[ $# -gt 0 ]]
 do
 	case "$1" in
 		-a|-ao) audiooffset="$2"; shift;;
-		--ab) audio_bitrate="$2" ; shift;;
+		-ab) audio_bitrate="$2" ; shift;;
 		-b|-vb) video_bitrate="$2"; shift;;
 		-c) videocodec="$2"; shift;;
 		-container) container="$2"; shift;;
@@ -224,18 +224,21 @@ BASE="\
 -thread_queue_size 512 \
 -threads $threads"
 
-VIDEO="-video_size $resolution \
+VIDEO="\
 -thread_queue_size 512 \
 -f x11grab \
+-video_size $resolution \
 -i $DISPLAY$offset \
 -r $framerate \
+-framerate $framerate \
 -c:v $videocodec \
+-profile:v high \
 -b:v ${video_bitrate}k \
 -minrate ${video_bitrate}k \
 -maxrate ${video_bitrate}k \
 -bufsize ${bufsize}k \
 -preset ultrafast \
--profile:v high \
+-tune zerolatency \
 -vf "${scaleres}format=yuv420p" \
 -g $gop \
 -keyint_min $framerate \


### PR DESCRIPTION
The [Twitch Broadcasting Guidelines](https://help.twitch.tv/s/article/broadcasting-guidelines?language=en_US) suggest that streams be encoded with CBR (constant bit rate), as opposed to VBR (variable bit rate), to reduce chances of buffering, dropped frames, or latency due to traffic routing/shaping from ISPs. This set of changes implements CBR in `fauxstream` as detailed in issue #6, plus some related fixes & optimizations in the use of `ffmpeg`.

Specifically:

* Always encodes at a constant bitrate
* Deprecates and renames the `fauxstream` `-b` (bitrate) option to `-vb` (video bitrate; default: `3500`.) The `-b` option is still retained for backwards compatibility.
* Deprecates and renames the `fauxstream` `-a` (audio offset) option to `-ao`. The `-a` option is still retained for backwards compatibility.
* Adds a new `fauxstream` `-ab` (audio bitrate; default: `96`, per Twitch's guidelines) option.
* Encodes audio at a constant bitrate, now using the 'fast' AAC coder.
* Replaces the use of the possibly-incorrect-or-nonexistent `ffmpeg` `-vb` option with the correct `-b:v` option when specifying the video bitrate.
* Ensures that `x11grab` only captures at the target frame-rate, as opposed to the display's refresh rate (which is often higher.)
* Specifies the x264 'high' profile be used for video encoding (currently hard-coded.)
* Improved configuration of keyframing every 2s, as advised in Twitch's guidelines.
* Tunes x264 video encoding for zero latency.
