### PR TITLE
Fixes scaleres (-s) option parsing

### DIFF
--- a/fauxstream
+++ b/fauxstream
@@ -134,7 +134,7 @@ done
 if [[ $preset_vaapi -eq 1 ]]; then
 	videocodec=h264_vaapi
 	video_device="-vaapi_device /dev/dri/renderD128"
-	if [[ -z "scaleres" ]]; then
+	if [[ -n "$scaleres" ]]; then
 		scale_w=$(echo $scaleres | cut -dx -f1)
 		scale_h=$(echo $scaleres | cut -dx -f2)
 		video_format="-vf "hwupload,scale_vaapi=w=${scale_w}:h=${scale_h}:format=nv12""
@@ -142,6 +142,9 @@ if [[ $preset_vaapi -eq 1 ]]; then
 		video_format="-vf "format=nv12,hwupload""
 	fi
 else
+	if [[ -n "$scaleres" ]]; then
+		scaleres="scale=${scaleres},"
+	fi
 	video_format="-vf "${scaleres}format=yuv420p""
 	video_output_fps= "-r $framerate"
 fi
@@ -149,9 +152,6 @@ fi
 bufsize=`expr $video_bitrate \* 2`
 gop=`expr $framerate \* 2`
 
-if [[ -z "$scaleres" ]]; then
-	scaleres="scale=${scaleres},"
-fi
 
 sndio_device="$(sndioctl -n server.device | cut -f1 -d'(')"
 


### PR DESCRIPTION
This fixes a minor bug in the `-s` option parsing and composition of the `scaleres` & `video_format` variables which was accidentally introduced in @rfht's PR #8. Specifically:

1) restores & fixes the use of `test -n` (non-zero) checks on the value of `$scaleres` (the new use in the VAAPI support logic was missing the `$` prefix, so was not checking the variable's value)
2) Moves the setting of `scaleres` to the non-VAAPI logic/block for to ensure that it is parsed/updated prior to composing the `video_format` string value.

This fixed errors for me when running _without_ the VAAPI profile (so the default x264 support), but should definitely be tested with VAAPI profile before approval/merge.