### PR TITLE
Potential desync fixes by using `aresample=async=1` filter

### DIFF
--- a/fauxstream
+++ b/fauxstream
@@ -269,38 +269,20 @@ AUDIOMERGE="\
 
 if [ $noaudio -lt 1 -a $mic -lt 1 ]; then
 	#only monitoring stream
-	RUN="ffmpeg $GLOBAL \
-		$MON_IN \
-		-f nut pipe:1 | \
-	ffmpeg $GLOBAL \
-		-thread_queue_size 64 \
-		-f nut -itsoffset $audiooffset -i pipe:0 \
-		-filter_complex aresample=async=1 \
-		$VIDEO_IN \
-		$VIDEO_CONV \
-		$AUDIO_CONV \
+	RUN="ffmpeg $GLOBAL $MON_IN -f nut pipe:1 | \
+	ffmpeg $GLOBAL -thread_queue_size 64 -f nut -itsoffset $audiooffset -i pipe:0 \
+		-filter_complex aresample=async=1 $VIDEO_IN $VIDEO_CONV $AUDIO_CONV \
 		-f "${container}" \"$filename\""
 elif [ $noaudio -lt 1 ]; then
 	#mon + mic stream
-	RUN="ffmpeg $GLOBAL \
-		$MIC_IN \
-		$MON_IN  \
-		-filter_complex \"${AUDIOMERGE}\" -map '[a]' \
+	RUN="ffmpeg $GLOBAL $MIC_IN $MON_IN  -filter_complex \"${AUDIOMERGE}\" -map '[a]' \
 		-f nut pipe:1 | \
-	ffmpeg $GLOBAL \
-		-thread_queue_size 64 \
-		-f nut -itsoffset $audiooffset -i pipe:0 \
-		-filter_complex aresample=async=1 \
-		$VIDEO_IN \
-		$VIDEO_CONV \
-		$AUDIO_CONV \
+	ffmpeg $GLOBAL -thread_queue_size 64 -f nut -itsoffset $audiooffset -i pipe:0 \
+		-filter_complex aresample=async=1 $VIDEO_IN $VIDEO_CONV $AUDIO_CONV \
 		-f "${container}" \"$filename\""
 else
 	#no audio
-	RUN="ffmpeg $GLOBAL \
-		$VIDEO_IN \
-		$VIDEO_CONV \
-		-f "${container}" \"$filename\""
+	RUN="ffmpeg $GLOBAL $VIDEO_IN $VIDEO_CONV -f "${container}" \"$filename\""
 fi
 
 echo "$RUN\n"

--- a/fauxstream
+++ b/fauxstream
@@ -213,12 +213,10 @@ echo "): ${resolution}${offset}\n"
 GLOBAL="\
 -hide_banner \
 -loglevel error \
--thread_queue_size 512 \
 -threads $threads\
 "
 
 VIDEO_IN="\
--thread_queue_size 512 \
 -show_region 1 \
 ${video_device} \
 -f x11grab \
@@ -244,13 +242,11 @@ ${video_format} \
 "
 
 MON_IN="\
--thread_queue_size 512 \
 -f sndio \
 -i snd/mon\
 "
 
 MIC_IN="\
--thread_queue_size 512 \
 -f sndio \
 -i "$mic_device"\
 "
@@ -272,15 +268,24 @@ AUDIOMERGE="\
 
 if [ $noaudio -lt 1 -a $mic -lt 1 ]; then
 	#only monitoring stream
-	RUN="ffmpeg $GLOBAL $MON_IN $AUDIO_CONV -f nut pipe:1 | \
-	ffmpeg $GLOBAL -thread_queue_size 512 -f nut -itsoffset $audiooffset -i pipe:0 \
-		$VIDEO_IN $VIDEO_CONV -c:a copy -f "${container}" \"$filename\""
+	RUN="ffmpeg $GLOBAL \
+    $MON_IN \
+    $AUDIO_CONV -f nut pipe:1 | \
+	ffmpeg $GLOBAL \
+    -f nut -itsoffset $audiooffset -i pipe:0 \
+		$VIDEO_IN $VIDEO_CONV -c:a copy \
+    -f "${container}" \"$filename\""
 elif [ $noaudio -lt 1 ]; then
 	#mon + mic stream
-	RUN="ffmpeg $GLOBAL $MIC_IN $MON_IN -filter_complex \"${AUDIOMERGE}\" \
-		-map '[a]' $AUDIO_CONV -f nut pipe:1 | \
-	ffmpeg $GLOBAL -thread_queue_size 512 -f nut -itsoffset $audiooffset -i pipe:0 \
-		$VIDEO_IN $VIDEO_CONV -c:a copy -f "${container}" \"$filename\""
+	RUN="ffmpeg $GLOBAL \
+    $MIC_IN \
+		$MON_IN  \
+		-filter_complex \"${AUDIOMERGE}\" -map '[a]' \
+    $AUDIO_CONV -f nut pipe:1 | \
+	ffmpeg $GLOBAL \
+    -f nut -itsoffset $audiooffset -i pipe:0 \
+		$VIDEO_IN $VIDEO_CONV -c:a copy \
+    -f "${container}" \"$filename\""
 else
 	#no audio
 	RUN="ffmpeg $GLOBAL $VIDEO_IN $VIDEO_CONV -f "${container}" \"$filename\""

--- a/fauxstream
+++ b/fauxstream
@@ -217,6 +217,7 @@ GLOBAL="\
 "
 
 VIDEO_IN="\
+-thread_queue_size 64 \
 -show_region 1 \
 ${video_device} \
 -f x11grab \
@@ -258,8 +259,8 @@ AUDIO_CONV="\
 "
 
 AUDIOMERGE="\
-[0]volume=$volume_mic,aformat=channel_layouts=stereo$hilopass[l];\
-[1]volume=$volume_mon,aformat=channel_layouts=stereo[m];\
+[0]aresample=async=1,volume=$volume_mic,aformat=channel_layouts=stereo$hilopass[l];\
+[1]aresample=async=1,volume=$volume_mon,aformat=channel_layouts=stereo[m];\
 [l][m]amix=inputs=2[a]\
 "
 
@@ -269,26 +270,37 @@ AUDIOMERGE="\
 if [ $noaudio -lt 1 -a $mic -lt 1 ]; then
 	#only monitoring stream
 	RUN="ffmpeg $GLOBAL \
-    $MON_IN \
-    $AUDIO_CONV -f nut pipe:1 | \
+		$MON_IN \
+		-f nut pipe:1 | \
 	ffmpeg $GLOBAL \
-    -f nut -itsoffset $audiooffset -i pipe:0 \
-		$VIDEO_IN $VIDEO_CONV -c:a copy \
-    -f "${container}" \"$filename\""
+		-thread_queue_size 64 \
+		-f nut -itsoffset $audiooffset -i pipe:0 \
+		-filter_complex aresample=async=1 \
+		$VIDEO_IN \
+		$VIDEO_CONV \
+		$AUDIO_CONV \
+		-f "${container}" \"$filename\""
 elif [ $noaudio -lt 1 ]; then
 	#mon + mic stream
 	RUN="ffmpeg $GLOBAL \
-    $MIC_IN \
+		$MIC_IN \
 		$MON_IN  \
 		-filter_complex \"${AUDIOMERGE}\" -map '[a]' \
-    $AUDIO_CONV -f nut pipe:1 | \
+		-f nut pipe:1 | \
 	ffmpeg $GLOBAL \
-    -f nut -itsoffset $audiooffset -i pipe:0 \
-		$VIDEO_IN $VIDEO_CONV -c:a copy \
-    -f "${container}" \"$filename\""
+		-thread_queue_size 64 \
+		-f nut -itsoffset $audiooffset -i pipe:0 \
+		-filter_complex aresample=async=1 \
+		$VIDEO_IN \
+		$VIDEO_CONV \
+		$AUDIO_CONV \
+		-f "${container}" \"$filename\""
 else
 	#no audio
-	RUN="ffmpeg $GLOBAL $VIDEO_IN $VIDEO_CONV -f "${container}" \"$filename\""
+	RUN="ffmpeg $GLOBAL \
+		$VIDEO_IN \
+		$VIDEO_CONV \
+		-f "${container}" \"$filename\""
 fi
 
 echo "$RUN\n"


### PR DESCRIPTION
**NOTE:** PR #12 should be merged prior to this PR.

I'll be doing some more live stream stress testing of this PR, but this _appears_ to fully resolve audio/video sync issues for me _and_ results in a _far_ more consistent CBR for my stream (without Twitch's frequent warnings about instabilities).

The short explanation: This uses `-thread_queue_size` much more conservatively and only on audio/video input on the encode side of the pipe. It also introduces the use of the `aresample=async=1` filter, both on the the merge of microphone & monitor audio for mix down to stereo _and_ on the encode side of the pipe so that video and audio (no longer encoded to AAC on the audio merge side of the pipe) are fully synchronized before writing to output file/stream.

For the detailed explanation, see [this comment](https://github.com/rfht/fauxstream/issues/5#issuecomment-3399576978) on issue #5.