### PR TITLE
Ensure CBR for audio

### DIFF
--- a/fauxstream
+++ b/fauxstream
@@ -48,7 +48,7 @@ USAGE="Usage: `basename $0` [-p preset] [-m] [-d mic_device] [-a audiooffset] [-
 
 audiooffset=0.0
 audio_bitrate=96
-bufsize=
+audio_bufsize=
 container=flv
 filename=
 framerate=30
@@ -70,6 +70,7 @@ scale_w=
 threads=0
 videocodec=libx264
 video_bitrate=3500
+video_bufsize=
 video_device=
 video_format=
 video_output_fps=
@@ -150,8 +151,9 @@ else
 	video_output_fps="-r $framerate"
 fi
 
-bufsize=`expr $video_bitrate \* 2`
-gop=`expr $framerate \* 2`
+audio_bufsize="$((audio_bitrate * 2))"
+video_bufsize="$((video_bitrate * 2))"
+gop="$((framerate * 2))"
 
 
 sndio_device="$(sndioctl -n server.device | cut -f1 -d'(')"
@@ -233,7 +235,7 @@ ${video_output_fps} \
 -b:v ${video_bitrate}k \
 -minrate ${video_bitrate}k \
 -maxrate ${video_bitrate}k \
--bufsize ${bufsize}k \
+-bufsize ${video_bufsize}k \
 -preset ultrafast \
 -tune zerolatency \
 ${video_format} \
@@ -255,6 +257,9 @@ MIC_IN="\
 AUDIO_CONV="\
 -c:a aac \
 -b:a ${audio_bitrate}k \
+-minrate ${audio_bitrate}k \
+-maxrate ${audio_bitrate}k \
+-bufsize ${audio_bufsize}k \
 -aac_coder fast\
 "
 

--- a/fauxstream
+++ b/fauxstream
@@ -269,38 +269,20 @@ AUDIOMERGE="\
 
 if [ $noaudio -lt 1 -a $mic -lt 1 ]; then
 	#only monitoring stream
-	RUN="ffmpeg $GLOBAL \
-		$MON_IN \
-		-f nut pipe:1 | \
-	ffmpeg $GLOBAL \
-		-thread_queue_size 64 \
-		-f nut -itsoffset $audiooffset -i pipe:0 \
-		-filter_complex aresample=async=1 \
-		$VIDEO_IN \
-		$VIDEO_CONV \
-		$AUDIO_CONV \
+	RUN="ffmpeg $GLOBAL $MON_IN -f nut pipe:1 | \
+	ffmpeg $GLOBAL -thread_queue_size 64 -f nut -itsoffset $audiooffset -i pipe:0 \
+		-filter_complex aresample=async=1 $VIDEO_IN $VIDEO_CONV $AUDIO_CONV \
 		-f "${container}" \"$filename\""
 elif [ $noaudio -lt 1 ]; then
 	#mon + mic stream
-	RUN="ffmpeg $GLOBAL \
-		$MIC_IN \
-		$MON_IN  \
-		-filter_complex \"${AUDIOMERGE}\" -map '[a]' \
+	RUN="ffmpeg $GLOBAL $MIC_IN $MON_IN  -filter_complex \"${AUDIOMERGE}\" -map '[a]' \
 		-f nut pipe:1 | \
-	ffmpeg $GLOBAL \
-		-thread_queue_size 64 \
-		-f nut -itsoffset $audiooffset -i pipe:0 \
-		-filter_complex aresample=async=1 \
-		$VIDEO_IN \
-		$VIDEO_CONV \
-		$AUDIO_CONV \
+	ffmpeg $GLOBAL -thread_queue_size 64 -f nut -itsoffset $audiooffset -i pipe:0 \
+		-filter_complex aresample=async=1 $VIDEO_IN $VIDEO_CONV $AUDIO_CONV \
 		-f "${container}" \"$filename\""
 else
 	#no audio
-	RUN="ffmpeg $GLOBAL \
-		$VIDEO_IN \
-		$VIDEO_CONV \
-		-f "${container}" \"$filename\""
+	RUN="ffmpeg $GLOBAL $VIDEO_IN $VIDEO_CONV -f "${container}" \"$filename\""
 fi
 
 echo "$RUN\n"

--- a/fauxstream
+++ b/fauxstream
@@ -213,12 +213,10 @@ echo "): ${resolution}${offset}\n"
 GLOBAL="\
 -hide_banner \
 -loglevel error \
--thread_queue_size 512 \
 -threads $threads\
 "
 
 VIDEO_IN="\
--thread_queue_size 512 \
 -show_region 1 \
 ${video_device} \
 -f x11grab \
@@ -244,13 +242,11 @@ ${video_format} \
 "
 
 MON_IN="\
--thread_queue_size 512 \
 -f sndio \
 -i snd/mon\
 "
 
 MIC_IN="\
--thread_queue_size 512 \
 -f sndio \
 -i "$mic_device"\
 "
@@ -272,15 +268,24 @@ AUDIOMERGE="\
 
 if [ $noaudio -lt 1 -a $mic -lt 1 ]; then
 	#only monitoring stream
-	RUN="ffmpeg $GLOBAL $MON_IN $AUDIO_CONV -f nut pipe:1 | \
-	ffmpeg $GLOBAL -thread_queue_size 512 -f nut -itsoffset $audiooffset -i pipe:0 \
-		$VIDEO_IN $VIDEO_CONV -c:a copy -f "${container}" \"$filename\""
+	RUN="ffmpeg $GLOBAL \
+    $MON_IN \
+    $AUDIO_CONV -f nut pipe:1 | \
+	ffmpeg $GLOBAL \
+    -f nut -itsoffset $audiooffset -i pipe:0 \
+		$VIDEO_IN $VIDEO_CONV -c:a copy \
+    -f "${container}" \"$filename\""
 elif [ $noaudio -lt 1 ]; then
 	#mon + mic stream
-	RUN="ffmpeg $GLOBAL $MIC_IN $MON_IN -filter_complex \"${AUDIOMERGE}\" \
-		-map '[a]' $AUDIO_CONV -f nut pipe:1 | \
-	ffmpeg $GLOBAL -thread_queue_size 512 -f nut -itsoffset $audiooffset -i pipe:0 \
-		$VIDEO_IN $VIDEO_CONV -c:a copy -f "${container}" \"$filename\""
+	RUN="ffmpeg $GLOBAL \
+    $MIC_IN \
+		$MON_IN  \
+		-filter_complex \"${AUDIOMERGE}\" -map '[a]' \
+    $AUDIO_CONV -f nut pipe:1 | \
+	ffmpeg $GLOBAL \
+    -f nut -itsoffset $audiooffset -i pipe:0 \
+		$VIDEO_IN $VIDEO_CONV -c:a copy \
+    -f "${container}" \"$filename\""
 else
 	#no audio
 	RUN="ffmpeg $GLOBAL $VIDEO_IN $VIDEO_CONV -f "${container}" \"$filename\""

--- a/fauxstream
+++ b/fauxstream
@@ -217,6 +217,7 @@ GLOBAL="\
 "
 
 VIDEO_IN="\
+-thread_queue_size 64 \
 -show_region 1 \
 ${video_device} \
 -f x11grab \
@@ -258,8 +259,8 @@ AUDIO_CONV="\
 "
 
 AUDIOMERGE="\
-[0]volume=$volume_mic,aformat=channel_layouts=stereo$hilopass[l];\
-[1]volume=$volume_mon,aformat=channel_layouts=stereo[m];\
+[0]aresample=async=1,volume=$volume_mic,aformat=channel_layouts=stereo$hilopass[l];\
+[1]aresample=async=1,volume=$volume_mon,aformat=channel_layouts=stereo[m];\
 [l][m]amix=inputs=2[a]\
 "
 
@@ -269,26 +270,37 @@ AUDIOMERGE="\
 if [ $noaudio -lt 1 -a $mic -lt 1 ]; then
 	#only monitoring stream
 	RUN="ffmpeg $GLOBAL \
-    $MON_IN \
-    $AUDIO_CONV -f nut pipe:1 | \
+		$MON_IN \
+		-f nut pipe:1 | \
 	ffmpeg $GLOBAL \
-    -f nut -itsoffset $audiooffset -i pipe:0 \
-		$VIDEO_IN $VIDEO_CONV -c:a copy \
-    -f "${container}" \"$filename\""
+		-thread_queue_size 64 \
+		-f nut -itsoffset $audiooffset -i pipe:0 \
+		-filter_complex aresample=async=1 \
+		$VIDEO_IN \
+		$VIDEO_CONV \
+		$AUDIO_CONV \
+		-f "${container}" \"$filename\""
 elif [ $noaudio -lt 1 ]; then
 	#mon + mic stream
 	RUN="ffmpeg $GLOBAL \
-    $MIC_IN \
+		$MIC_IN \
 		$MON_IN  \
 		-filter_complex \"${AUDIOMERGE}\" -map '[a]' \
-    $AUDIO_CONV -f nut pipe:1 | \
+		-f nut pipe:1 | \
 	ffmpeg $GLOBAL \
-    -f nut -itsoffset $audiooffset -i pipe:0 \
-		$VIDEO_IN $VIDEO_CONV -c:a copy \
-    -f "${container}" \"$filename\""
+		-thread_queue_size 64 \
+		-f nut -itsoffset $audiooffset -i pipe:0 \
+		-filter_complex aresample=async=1 \
+		$VIDEO_IN \
+		$VIDEO_CONV \
+		$AUDIO_CONV \
+		-f "${container}" \"$filename\""
 else
 	#no audio
-	RUN="ffmpeg $GLOBAL $VIDEO_IN $VIDEO_CONV -f "${container}" \"$filename\""
+	RUN="ffmpeg $GLOBAL \
+		$VIDEO_IN \
+		$VIDEO_CONV \
+		-f "${container}" \"$filename\""
 fi
 
 echo "$RUN\n"


### PR DESCRIPTION
**NOTE:** _This is applied ontop of PR #13, which fixes audio/video desync. I'll rebase this as that PR is updated and merged (hopefully.)_

As noted in issue #11, I had found that while my now-merged implementation of CBR (constant bit rate) in issue #6 has been working well, I was seeing fluctuations in the audio bit rate.

While our use of the AAC encoder implies it should be generating CBR, I found that `ffmpeg` supports the `-minrate`, `-maxrate`, and `-bufsize` options for all encoders. So, this splits our buffer size variables into audio & video versions and sets `-minrate`, `-maxrate`, and `-bufsize` appropriately to produce a CBR for both audio & video.

It has been working correctly in my testing, but I'll want to re-test after #13 is merged.